### PR TITLE
Fix call to validation during training (0.2.0 => 0.2.1)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.2.1
 commit = True
 tag = False
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,6 +4,7 @@ matplotlib>=3.3.4
 pandas>=1.1.0
 pylint>=2.7.0
 pytest>=6.2.2
+pytest-mock>=3.6.1
 torch>=1.7.1
 torchvision>=0.8.2
 tqdm>=4.56.0

--- a/easyfsl/__init__.py
+++ b/easyfsl/__init__.py
@@ -5,4 +5,4 @@ This library implements few-shot learning methods, along with data loading tools
 for few-shot learning experiences.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/easyfsl/methods/abstract_meta_learner.py
+++ b/easyfsl/methods/abstract_meta_learner.py
@@ -219,7 +219,7 @@ class AbstractMetaLearner(nn.Module):
 
                 # Validation
                 if val_loader:
-                    if episode_index + 1 % validation_frequency == 0:
+                    if (episode_index + 1) % validation_frequency == 0:
                         self.validate(val_loader)
 
     def validate(self, val_loader: DataLoader) -> float:

--- a/easyfsl/tests/data_tools/easy_set_test.py
+++ b/easyfsl/tests/data_tools/easy_set_test.py
@@ -92,9 +92,10 @@ class TestEasySetListDataInstances:
             )
         ],
     )
-    def test_list_data_instances_returns_expected_values(class_roots, images, labels):
-        with patch("pathlib.Path.glob") as mock_glob:
-            mock_glob.return_value = [Path("a.png"), Path("b.png")]
-            with patch("pathlib.Path.is_file") as mock_is_file:
-                mock_is_file.return_value = True
-                assert (images, labels) == EasySet.list_data_instances(class_roots)
+    def test_list_data_instances_returns_expected_values(
+        class_roots, images, labels, mocker
+    ):
+        mocker.patch("pathlib.Path.glob", return_value=[Path("a.png"), Path("b.png")])
+        mocker.patch("pathlib.Path.is_file", return_value=True)
+
+        assert (images, labels) == EasySet.list_data_instances(class_roots)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="easyfsl",
-    version="0.2.0",
+    version="0.2.1",
     description="Ready-to-use PyTorch code to boost your way into few-shot image classification",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
`fit()` method used to never call `validate()`. I fixed the typo causing this.

I also added a test for this. I needed `mocker.spy` for the test, so I used this opportunity to switch from unittest mocking to pytest mocking.