### PR TITLE
Make EasySet supported_formats not case sensitive

### DIFF
--- a/easyfsl/datasets/easy_set.py
+++ b/easyfsl/datasets/easy_set.py
@@ -114,7 +114,7 @@ class EasySet(FewShotDataset):
             class_images = [
                 str(image_path)
                 for image_path in sorted(Path(class_root).glob("*"))
-                if image_path.is_file() & (image_path.suffix in supported_formats)
+                if image_path.is_file() & (image_path.suffix.lower() in supported_formats)
             ]
             images += class_images
             labels += len(class_images) * [class_id]


### PR DESCRIPTION
Currently, the supported_formats is case sensitive. Maybe it would be easier to make it case insensitive so that there's no need to handle different capitalization cases.