### PR TITLE
Fix for error: has no attribute 'get_labels'

### DIFF
--- a/notebooks/my_first_few_shot_classifier.ipynb
+++ b/notebooks/my_first_few_shot_classifier.ipynb
@@ -547,7 +547,7 @@
     "N_TRAINING_EPISODES = 40000\n",
     "N_VALIDATION_TASKS = 100\n",
     "\n",
-    "train_set.labels = [instance[1] for instance in train_set._flat_character_images]\n",
+    "train_set.get_labels = lambda: [instance[1] for instance in train_set._flat_character_images]\n",
     "train_sampler = TaskSampler(\n",
     "    train_set, n_way=N_WAY, n_shot=N_SHOT, n_query=N_QUERY, n_tasks=N_TRAINING_EPISODES\n",
     ")\n",


### PR DESCRIPTION
When running cells in order below AttributeError occurs as train_set.labels is created instead of train_set.get_labels.



---------------------------------------------------------------------------

AttributeError                            Traceback (most recent call last)

<ipython-input-9-71ba0b13fd5d> in <module>()
      9 
     10 train_sampler = TaskSampler(
---> 11     train_set, n_way=N_WAY, n_shot=N_SHOT, n_query=N_QUERY, n_tasks=N_TRAINING_EPISODES
     12 )
     13 train_loader = DataLoader(

/usr/local/lib/python3.7/dist-packages/easyfsl/samplers/task_sampler.py in __init__(self, dataset, n_way, n_shot, n_query, n_tasks)
     39 
     40         self.items_per_label = {}
---> 41         for item, label in enumerate(dataset.get_labels()):
     42             if label in self.items_per_label.keys():
     43                 self.items_per_label[label].append(item)

AttributeError: 'Omniglot' object has no attribute 'get_labels'