### PR TITLE
Fix TaskSampler

### DIFF
--- a/easyfsl/datasets/easy_set.py
+++ b/easyfsl/datasets/easy_set.py
@@ -114,7 +114,8 @@ class EasySet(FewShotDataset):
             class_images = [
                 str(image_path)
                 for image_path in sorted(Path(class_root).glob("*"))
-                if image_path.is_file() & (image_path.suffix.lower() in supported_formats)
+                if image_path.is_file()
+                & (image_path.suffix.lower() in supported_formats)
             ]
             images += class_images
             labels += len(class_images) * [class_id]

--- a/easyfsl/datasets/easy_set.py
+++ b/easyfsl/datasets/easy_set.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from pathlib import Path
 from typing import List, Union, Set, Tuple, Callable
 
@@ -117,8 +118,16 @@ class EasySet(FewShotDataset):
                 if image_path.is_file()
                 & (image_path.suffix.lower() in supported_formats)
             ]
+
             images += class_images
             labels += len(class_images) * [class_id]
+
+        if len(images) == 0:
+            warnings.warn(
+                UserWarning(
+                    "No images found in the specified directories. The dataset will be empty"
+                )
+            )
 
         return images, labels
 

--- a/easyfsl/datasets/mini_imagenet.py
+++ b/easyfsl/datasets/mini_imagenet.py
@@ -90,7 +90,7 @@ class MiniImageNet(FewShotDataset):
             self.transform = (
                 transform if transform else default_transform(image_size, training)
             )
-            self.images = None
+            self.images = self.data_df.image_path.tolist()
 
         self.class_names = self.data_df.class_name.unique()
         self.class_to_label = {v: k for k, v in enumerate(self.class_names)}

--- a/easyfsl/samplers/task_sampler.py
+++ b/easyfsl/samplers/task_sampler.py
@@ -1,5 +1,5 @@
 import random
-from typing import List, Tuple
+from typing import List, Tuple, Iterator
 
 import torch
 from torch import Tensor
@@ -44,10 +44,10 @@ class TaskSampler(Sampler):
             else:
                 self.items_per_label[label] = [item]
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self.n_tasks
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[List[int]]:
         for _ in range(self.n_tasks):
             yield torch.cat(
                 [
@@ -60,7 +60,7 @@ class TaskSampler(Sampler):
                     # pylint: enable=not-callable
                     for label in random.sample(self.items_per_label.keys(), self.n_way)
                 ]
-            )
+            ).tolist()
 
     def episodic_collate_fn(
         self, input_data: List[Tuple[Tensor, int]]

--- a/easyfsl/tests/datasets/easy_set_test.py
+++ b/easyfsl/tests/datasets/easy_set_test.py
@@ -12,12 +12,13 @@ def init_easy_set(specs):
     buffer = json.dumps(specs)
     with patch("builtins.open", mock_open(read_data=buffer)):
         with patch("pathlib.Path.glob") as mock_glob:
-            mock_glob.return_value = [Path("a"), Path("b")]
+            mock_glob.return_value = [Path("a.jpeg"), Path("b.jpeg")]
             EasySet(Path("dummy.json"))
 
 
 class TestEasySetInit:
     @staticmethod
+    @pytest.mark.filterwarnings("ignore::UserWarning")
     @pytest.mark.parametrize(
         "specs",
         [
@@ -149,6 +150,7 @@ class TestTieredImagenet:
             "test",
         ],
     )
+    @pytest.mark.filterwarnings("ignore::UserWarning")
     def test_tiered_imagenet_builds_easyset(split, mocker):
         mocker.patch(
             "pathlib.Path.glob",

--- a/easyfsl/tests/samplers/task_sampler_test.py
+++ b/easyfsl/tests/samplers/task_sampler_test.py
@@ -1,21 +1,34 @@
-from unittest.mock import patch
+from typing import Tuple, List
 
 import pytest
+from torch import Tensor
 
 from easyfsl.datasets import FewShotDataset
 from easyfsl.samplers import TaskSampler
 
 
+class DummyFewShotDataset(FewShotDataset):
+    def __init__(self, labels):
+        self.labels = labels
+
+    def __getitem__(self, item: int) -> Tuple[Tensor, int]:
+        raise NotImplementedError("__getitem__() is not supposed to be called.")
+
+    def __len__(self) -> int:
+        raise NotImplementedError("__len__() is not supposed to be called.")
+
+    def get_labels(self) -> List[int]:
+        return self.labels
+
+
 def init_task_sampler(labels, n_way, n_shot, n_query, n_tasks):
-    with patch("easyfsl.datasets.FewShotDataset.get_labels", return_value=labels):
-        print(labels)
-        return TaskSampler(
-            dataset=FewShotDataset(),
-            n_way=n_way,
-            n_shot=n_shot,
-            n_query=n_query,
-            n_tasks=n_tasks,
-        )
+    return TaskSampler(
+        dataset=DummyFewShotDataset(labels=labels),
+        n_way=n_way,
+        n_shot=n_shot,
+        n_query=n_query,
+        n_tasks=n_tasks,
+    )
 
 
 class TestTaskSamplerIter:

--- a/easyfsl/tests/samplers/task_sampler_test.py
+++ b/easyfsl/tests/samplers/task_sampler_test.py
@@ -27,6 +27,20 @@ class TestTaskSamplerIter:
             "n_query": 1,
             "n_tasks": 5,
         },
+        {
+            "labels": ["label0", "label0", "label0", 1, 1, 1, 2, 2, 2],
+            "n_way": 2,
+            "n_shot": 1,
+            "n_query": 1,
+            "n_tasks": 5,
+        },
+        {
+            "labels": [0, 0, 0, 1, 1, 1, 2, 2, 2],
+            "n_way": 3,
+            "n_shot": 2,
+            "n_query": 1,
+            "n_tasks": 5,
+        },
     ]
 
     @staticmethod
@@ -42,3 +56,28 @@ class TestTaskSamplerIter:
             assert isinstance(batch, list)
             for item in batch:
                 assert isinstance(item, int)
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "labels,n_way,n_shot,n_query,n_tasks",
+        [tuple(case.values()) for case in cases_grid],
+    )
+    def test_task_sampler_iter_yields_list_of_correct_len(
+        labels, n_way, n_shot, n_query, n_tasks
+    ):
+        sampler = init_task_sampler(labels, n_way, n_shot, n_query, n_tasks)
+        for batch in sampler:
+            assert len(batch) == n_way * (n_shot + n_query)
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "labels,n_way,n_shot,n_query,n_tasks",
+        [tuple(case.values()) for case in cases_grid],
+    )
+    def test_task_sampler_iter_yields_items_smaller_than_dataset_len(
+        labels, n_way, n_shot, n_query, n_tasks
+    ):
+        sampler = init_task_sampler(labels, n_way, n_shot, n_query, n_tasks)
+        for batch in sampler:
+            for item in batch:
+                assert item < len(labels)

--- a/easyfsl/tests/samplers/task_sampler_test.py
+++ b/easyfsl/tests/samplers/task_sampler_test.py
@@ -1,0 +1,44 @@
+from unittest.mock import patch
+
+import pytest
+
+from easyfsl.datasets import FewShotDataset
+from easyfsl.samplers import TaskSampler
+
+
+def init_task_sampler(labels, n_way, n_shot, n_query, n_tasks):
+    with patch("easyfsl.datasets.FewShotDataset.get_labels", return_value=labels):
+        print(labels)
+        return TaskSampler(
+            dataset=FewShotDataset(),
+            n_way=n_way,
+            n_shot=n_shot,
+            n_query=n_query,
+            n_tasks=n_tasks,
+        )
+
+
+class TestTaskSamplerIter:
+    cases_grid = [
+        {
+            "labels": [0, 0, 0, 1, 1, 1, 2, 2, 2],
+            "n_way": 2,
+            "n_shot": 1,
+            "n_query": 1,
+            "n_tasks": 5,
+        },
+    ]
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "labels,n_way,n_shot,n_query,n_tasks",
+        [tuple(case.values()) for case in cases_grid],
+    )
+    def test_task_sampler_iter_yields_list_of_int(
+        labels, n_way, n_shot, n_query, n_tasks
+    ):
+        sampler = init_task_sampler(labels, n_way, n_shot, n_query, n_tasks)
+        for batch in sampler:
+            assert isinstance(batch, list)
+            for item in batch:
+                assert isinstance(item, int)


### PR DESCRIPTION
Fix an error in TaskSampler: `TaskSampler.__iter__()` used to yield a torch Tensor, but the expected interface for samplers would be a list of integers.

This caused calls to the `__get_item__()` method of `Dataset` objects used with `TaskSampler` with single-integer-element tensors as input (e.g. `tensor(42)`), and ultimately caused errors in `MiniImageNet` and `DanishFungi` as pointed out in #41 .

I fixed this by forcing `TaskSampler.__iter__()` to return a list.

I also took the opportunity to add a `UserWarning` in `EasySet` when the `list_data_instances()` method can't find any image. Before that, if there was a problem with your paths to images, it was unintuitive to debug.