### PR TITLE
Adding deepcopy to best_state deriving

### DIFF
--- a/notebooks/episodic_training.ipynb
+++ b/notebooks/episodic_training.ipynb
@@ -384,6 +384,7 @@
    },
    "outputs": [],
    "source": [
+    "import copy\n",
     "from easyfsl.utils import evaluate\n",
     "\n",
     "\n",
@@ -398,7 +399,7 @@
     "\n",
     "    if validation_accuracy > best_validation_accuracy:\n",
     "        best_validation_accuracy = validation_accuracy\n",
-    "        best_state = few_shot_classifier.state_dict()\n",
+    "        best_state = copy.deepcopy(few_shot_classifier.state_dict()) # Deepcopy because state_dict returns ref\n",
     "        print(\"Ding ding ding! We found a new best model!\")\n",
     "\n",
     "    tb_writer.add_scalar(\"Train/loss\", average_loss, epoch)\n",


### PR DESCRIPTION
The initial code needs to be corrected. state_dict stores a reference to the dictionary, not it's copy. See: [SAVING AND LOADING MODELS](https://pytorch.org/tutorials/beginner/saving_loading_models.html#:~:text=If%20you%20only,the%20overfitted%20model.)