### PR TITLE
Update comment block to warn user of possible bug in PyTorch DataLoader

### DIFF
--- a/notebooks/my_first_few_shot_classifier.ipynb
+++ b/notebooks/my_first_few_shot_classifier.ipynb
@@ -522,7 +522,11 @@
     "This guarantees that at test time, the model will have to classify characters that were not seen during training.\n",
     "\n",
     "Note that we don't set a validation set here to keep this notebook concise,\n",
-    "but keep in mind that **this is not good practice** and you should always use validation when training a model for production."
+    "but keep in mind that **this is not good practice** and you should always use validation when training a model for production.",
+    "\n",
+    "Note: Currently, there is a bug in PyTorch DataLoader for Mac/Windows users that makes it impossible to use multiple workers with custom `get_labels` function.\n",
+    "You can set `num_workers=0` to avoid this issue when instantiating the DataLoader in the next cell.\n",
+    "Read more about the [issue](https://github.com/sicara/easy-few-shot-learning/issues/51)."
    ],
    "metadata": {
     "collapsed": false,


### PR DESCRIPTION
## Summary

- Fix #152 

## Modification

- Update a comment block in `notebooks/my_first_few_shot_classifier.ipynb` so that Win/Mac users can patch the bug in in PyTorch DataLoader. The following is the added comment.

```md
Note: Currently, there is a bug in PyTorch DataLoader for Mac/Windows users that makes it impossible to use multiple workers with custom `get_labels` function.
You can set `num_workers=0` to avoid this issue when instantiating the DataLoader in the next cell.
Read more about the [issue](https://github.com/sicara/easy-few-shot-learning/issues/51).
```

